### PR TITLE
v2.4.4: es2020 + npmjs.com/@sleaze hosting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
-  "name": "@cocalc/local-storage-lru",
+  "name": "@sleaze/local-storage-lru",
   "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@cocalc/local-storage-lru",
+      "name": "@sleaze/local-storage-lru",
       "version": "2.4.3",
       "license": "APACHE-2.0",
+      "dependencies": {
+        "node": "^18.20.2"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.11",
         "istanbul-badges-readme": "^1.8.1",
@@ -3389,6 +3392,26 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/node": {
+      "version": "18.20.2",
+      "resolved": "https://registry.npmjs.org/node/-/node-18.20.2.tgz",
+      "integrity": "sha512-GEfhC/XFGqHFIKuRUd6pfCHrF9ZlizlMCy3EH5tSIwzOLrY8Qn1YSQV1pxUl007JxZnlIxNLnuRV6jOn6a6b2Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-bin-setup": "^1.0.0"
+      },
+      "bin": {
+        "node": "bin/node"
+      },
+      "engines": {
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/node-bin-setup": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-bin-setup/-/node-bin-setup-1.1.3.tgz",
+      "integrity": "sha512-opgw9iSCAzT2+6wJOETCpeRYAQxSopqQ2z+N6BXwIMsQQ7Zj5M8MaafQY8JMlolRR6R1UXg2WmhKp0p9lSOivg=="
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sleaze/local-storage-lru",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sleaze/local-storage-lru",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "APACHE-2.0",
       "dependencies": {
         "node": "^18.20.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sleaze/local-storage-lru",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Simple LRU cache for a browser's localStorage",
   "main": "./lib/index.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@cocalc/local-storage-lru",
+  "name": "@sleaze/local-storage-lru",
   "version": "2.4.3",
   "description": "Simple LRU cache for a browser's localStorage",
   "main": "./lib/index.js",
@@ -53,5 +53,8 @@
   ],
   "bugs": {
     "url": "https://github.com/sagemathinc/local-storage-lru/issues"
+  },
+  "dependencies": {
+    "node": "^18.20.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2020",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
v2.4.4: Updated for es2020 + npmjs.com/@sleaze hosting.